### PR TITLE
Use HTTPS CDN link

### DIFF
--- a/src/main/java/io/spring/asciidoctor/CodeBlockSwitchPostprocessor.java
+++ b/src/main/java/io/spring/asciidoctor/CodeBlockSwitchPostprocessor.java
@@ -35,7 +35,7 @@ public class CodeBlockSwitchPostprocessor extends Postprocessor {
 		String css = readResource("/codeBlockSwitch.css");
 		String javascript = readResource("/codeBlockSwitch.js");
 		String replacement = String.format("<style>%n%s%n</style>%n" +
-				"<script src=\"http://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js\"></script>%n" +
+				"<script src=\"https://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js\"></script>%n" +
 				"<script type=\"text/javascript\">%n%s%n</script>%n</head>%n", css, javascript);
 		return output.replace("</head>", replacement);
 	}


### PR DESCRIPTION
This change is a quick fix for "Mixed content" browser warnings that appear if HTML is loaded
via HTTPS connection.