### PR TITLE
Code blocks with multiple different titles do not toggle

### DIFF
--- a/block-switch/block-switch-core/src/main/resources/blockSwitch.js
+++ b/block-switch/block-switch-core/src/main/resources/blockSwitch.js
@@ -38,7 +38,7 @@ function createSwitchItem(block, blockSwitch) {
 
 function globalSwitch() {
 	$('.switch--item').each(function() {
-		blockId = blockIdForSwitchItem($(this));
+		var blockId = blockIdForSwitchItem($(this));
 		$(this).off('click');
 		$(this).on('click', function() {
 			selectedText = $(this).text()


### PR DESCRIPTION
Make `blockId` a local variable so that it is not overwritten by every iteration over "switch--item".

Closes gh-44